### PR TITLE
Recredit Kohi and Sparaze

### DIFF
--- a/album/catch-322.yaml
+++ b/album/catch-322.yaml
@@ -200,7 +200,7 @@ Duration: '3:45'
 Artists:
 - Alex Votl
 Cover Artists:
-- Eliora Spar
+- Sparaze
 URLs:
 - https://vasterror.bandcamp.com/track/im-right-here
 ---

--- a/album/repiton.yaml
+++ b/album/repiton.yaml
@@ -102,7 +102,7 @@ URLs:
 ---
 Track: Take The Shot
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Duration: '3:38'
 URLs:
 - https://vasterror.bandcamp.com/track/take-the-shot

--- a/album/vast-error-vol-1-3.yaml
+++ b/album/vast-error-vol-1-3.yaml
@@ -10,7 +10,7 @@ Wallpaper Artists:
 URLs:
 - https://vasterror.bandcamp.com/album/vast-error-vol-1-3
 Cover Artists:
-- Eliora Spar
+- Sparaze
 - Joyfulldreams
 Cover Art File Extension: png
 Track Art File Extension: png
@@ -104,7 +104,7 @@ Track: A Very Active Imagination
 Directory: a-very-active-imagination-vol-1-3
 Originally Released As: A Very Active Imagination
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Duration: '03:38'
 URLs:
 - https://vasterror.bandcamp.com/track/a-very-active-imagination-2
@@ -210,7 +210,7 @@ Track: On Repeat
 Directory: on-repeat-vol-1-3
 Originally Released As: On Repeat (Intermission)
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Duration: '02:14'
 URLs:
 - https://vasterror.bandcamp.com/track/on-repeat
@@ -235,7 +235,7 @@ Track: Third Eye
 Directory: third-eye-vol-1-3
 Originally Released As: Third Eye
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Duration: '02:25'
 URLs:
 - https://vasterror.bandcamp.com/track/third-eye-2
@@ -423,7 +423,7 @@ Track: Sortir
 Directory: sortir-vol-1-3
 Originally Released As: Sortir
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Duration: '03:46'
 URLs:
 - https://vasterror.bandcamp.com/track/sortir-2

--- a/album/vast-error-vol-1.yaml
+++ b/album/vast-error-vol-1.yaml
@@ -5,7 +5,7 @@ Date Added: October 14, 2023
 URLs:
 - https://archive.org/details/VastError_Volume1/
 Cover Artists:
-- Eliora Spar
+- Sparaze
 - Joyfulldreams
 Cover Art File Extension: png
 Track Art File Extension: png
@@ -54,7 +54,7 @@ Track: A Very Active Imagination
 Artists:
 - Kal-la-kal-la
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Duration: '03:38'
 URLs:
 - https://vasterror.bandcamp.com/track/a-very-active-imagination-2
@@ -63,7 +63,7 @@ Track: Plink
 Artists:
 - Ian Kraemer
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Duration: '04:12'
 URLs:
 - https://archive.org/details/VastError_Volume1/06+Plink.mp3
@@ -108,7 +108,7 @@ Track: Renaissance
 Artists:
 - Ian Kraemer
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Duration: '07:06'
 URLs:
 - https://archive.org/details/VastError_Volume1/11+Renaissance.mp3
@@ -117,7 +117,7 @@ Track: Renaissance (Extended Cut)
 Artists:
 - Ian Kraemer
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Duration: '08:34'
 URLs:
 - https://archive.org/details/VastError_Volume1/12+Renaissance+(Extended+Cut).mp3

--- a/album/vast-error-vol-2.yaml
+++ b/album/vast-error-vol-2.yaml
@@ -5,7 +5,7 @@ Date Added: October 14, 2023
 URLs:
 - https://archive.org/details/VastError_Volume2
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Cover Art File Extension: png
 Track Art File Extension: png
 Color: '#656565'
@@ -205,7 +205,7 @@ Track: Sortir
 Artists:
 - Husr
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Referenced Tracks:
 - Sortir (Alpha Demo)
 - Curtain Call

--- a/album/vast-error-vol-3.yaml
+++ b/album/vast-error-vol-3.yaml
@@ -5,7 +5,7 @@ Date Added: October 14, 2023
 URLs:
 - https://archive.org/details/VastError_Volume1/
 Cover Artists:
-- Eliora Spar
+- Sparaze
 - Joyfulldreams
 Cover Art File Extension: png
 Track Art File Extension: png
@@ -131,7 +131,7 @@ Track: Third Eye
 Artists:
 - Kurtis Burton
 Cover Artists:
-- Eliora Spar
+- Sparaze
 Referenced Tracks:
 - 'Beyond the Wall (Intermission)'
 Duration: '02:25'

--- a/album/vast-error-vol-4.yaml
+++ b/album/vast-error-vol-4.yaml
@@ -331,7 +331,7 @@ Duration: '2:32'
 Artists:
 - dbnet18
 Cover Artists:
-- Eliora Spar
+- Sparaze
 URLs:
 - https://vasterror.bandcamp.com/track/chamber-cultist
 ---

--- a/artists.yaml
+++ b/artists.yaml
@@ -7241,11 +7241,12 @@ Artist: Spades
 Dead URLs:
 - https://spectralspades.tumblr.com/
 ---
-Artist: Eliora Spar
+Artist: Sparaze
 Aliases:
-- Sparaze
+- Eliora Spar
+- Heather
 URLs:
-- https://twitter.com/elioraspar
+- https://twitter.com/ElioraSpar
 ---
 Artist: Sparky
 Aliases:

--- a/artists.yaml
+++ b/artists.yaml
@@ -367,8 +367,6 @@ Artist: Andrea Libman
 ---
 Artist: Andrea McNeil
 ---
-Artist: Andrew D.
----
 Artist: Andrew Gold
 ---
 Artist: Andrew Huang
@@ -4261,6 +4259,12 @@ URLs:
 - https://twitter.com/kohauro
 - https://kohauro.carrd.co/
 - https://vgen.co/kohauro
+---
+Artist: Kohi
+Aliases:
+- Andrew D.
+URLs:
+- https://twitter.com/Kohilaice
 ---
 Artist: Koji Kondo
 ---

--- a/flashes.yaml
+++ b/flashes.yaml
@@ -2196,7 +2196,7 @@ Contributors:
 - Magdalena Clark (writing)
 - 'Andy R. (art: characters)'
 - 'Gina Chacón (art: backgrounds, endings)'
-- Andrew D. (programming)
+- Kohi (programming)
 Date: February 19, 2020
 Featured Tracks:
 - 2chords
@@ -2208,7 +2208,7 @@ Contributors:
 - Lalo Hunt (writing)
 - 'Haven Daniels-Taylor (art: characters)'
 - 'Courtney Brendle (art: backgrounds, endings)'
-- Andrew D. (programming)
+- Kohi (programming)
 Date: March 4, 2020
 Featured Tracks:
 - 2chords
@@ -4039,7 +4039,7 @@ Contributors:
 - Andrew Hussie (author)
 - Clark Powell (musician)
 - Adelaide Killigan (lead engineer)
-- Andrew D. (additional engineering)
+- Kohi (additional engineering)
 - Aysha U. Farah (editing)
 - Yitong Zhu (language proofreading)
 - Raissa Castro (language proofreading)


### PR DESCRIPTION
Previously listed as Andrew D. and Eliora Spar; Kohi and Sparaze are their respective primary online/professional names.